### PR TITLE
Login middleware

### DIFF
--- a/src/controllers/consts.go
+++ b/src/controllers/consts.go
@@ -4,6 +4,7 @@ const (
 	perPage = 30
 
 	UserKey              = "user"
+	IsAdminKey           = "isAdmin"
 	UserRepositoryKey    = "userRepository"
 	MessageRepositoryKey = "messageRepository"
 )

--- a/src/controllers/consts.go
+++ b/src/controllers/consts.go
@@ -3,6 +3,7 @@ package controllers
 const (
 	perPage = 30
 
+	UserKey              = "user"
 	UserRepositoryKey    = "userRepository"
 	MessageRepositoryKey = "messageRepository"
 )

--- a/src/controllers/controllers.go
+++ b/src/controllers/controllers.go
@@ -41,6 +41,7 @@ func SetupRouter(openDatabase database.OpenDatabaseFunc) *gin.Engine {
 	authed := r.Group("/")
 	authed.Use(AuthRequired())
 	authed.GET("/login", LoginGet)
+	authed.POST("/fllws/:username", FollowPostController)
 
 	return r
 }

--- a/src/controllers/controllers.go
+++ b/src/controllers/controllers.go
@@ -29,18 +29,16 @@ func SetupRouter(openDatabase database.OpenDatabaseFunc) *gin.Engine {
 	r.Use(CORSMiddleware())
 	r.Use(beforeRequest(openDatabase))
 
-	r.POST("/fllws/:username", FollowPostController)
 	r.GET("/fllws/:username", FollowGetController)
-	r.GET("/feed", GetFeedMessages)
 	r.GET("/msgs", GetMessages)
 	r.GET("/msgs/:username", GetUserMessages)
 	r.POST("/msgs/:username", PostUserMessage)
-	r.GET("/login", LoginGet)
 	r.POST("/register", RegisterController)
 
 	authed := r.Group("/")
 	authed.Use(AuthRequired())
 	authed.GET("/login", LoginGet)
+	authed.GET("/feed", GetFeedMessages)
 	authed.POST("/fllws/:username", FollowPostController)
 
 	return r

--- a/src/controllers/controllers.go
+++ b/src/controllers/controllers.go
@@ -32,7 +32,6 @@ func SetupRouter(openDatabase database.OpenDatabaseFunc) *gin.Engine {
 	r.GET("/fllws/:username", FollowGetController)
 	r.GET("/msgs", GetMessages)
 	r.GET("/msgs/:username", GetUserMessages)
-	r.POST("/msgs/:username", PostUserMessage)
 	r.POST("/register", RegisterController)
 
 	authed := r.Group("/")
@@ -40,6 +39,7 @@ func SetupRouter(openDatabase database.OpenDatabaseFunc) *gin.Engine {
 	authed.GET("/login", LoginGet)
 	authed.GET("/feed", GetFeedMessages)
 	authed.POST("/fllws/:username", FollowPostController)
+	authed.POST("/msgs/:username", PostUserMessage)
 
 	return r
 }

--- a/src/controllers/controllers.go
+++ b/src/controllers/controllers.go
@@ -38,6 +38,10 @@ func SetupRouter(openDatabase database.OpenDatabaseFunc) *gin.Engine {
 	r.GET("/login", LoginGet)
 	r.POST("/register", RegisterController)
 
+	authed := r.Group("/")
+	authed.Use(AuthRequired())
+	authed.GET("/login", LoginGet)
+
 	return r
 }
 

--- a/src/controllers/follow.go
+++ b/src/controllers/follow.go
@@ -34,7 +34,7 @@ func FollowPostController(c *gin.Context) {
 		return
 	}
 
-	authUser := c.MustGet("user").(*models.User)
+	authUser := c.MustGet(UserKey).(*models.User)
 	if authUser.Username != urlUsername {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "the URL username did not match the Authorization header username"})
 		return

--- a/src/controllers/follow.go
+++ b/src/controllers/follow.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/Devops-2022-Group-R/itu-minitwit/src/database"
+	"github.com/Devops-2022-Group-R/itu-minitwit/src/models"
 )
 
 type FollowRequestBody struct {
@@ -33,10 +34,8 @@ func FollowPostController(c *gin.Context) {
 		return
 	}
 
-	if authUsername, err := GetAuthState(c); authUsername == "" || err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
-		return
-	} else if authUsername != urlUsername {
+	authUser := c.MustGet("user").(*models.User)
+	if authUser.Username != urlUsername {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "the URL username did not match the Authorization header username"})
 		return
 	}

--- a/src/controllers/login.go
+++ b/src/controllers/login.go
@@ -73,7 +73,7 @@ func AuthRequired() gin.HandlerFunc {
 			return
 		}
 
-		c.Set("user", user)
+		c.Set(UserKey, user)
 		c.Next()
 	}
 }

--- a/src/controllers/login.go
+++ b/src/controllers/login.go
@@ -73,6 +73,12 @@ func AuthRequired() gin.HandlerFunc {
 			return
 		}
 
+		if c.GetHeader("Authorization") == "Basic c2ltdWxhdG9yOnN1cGVyX3NhZmUh" {
+			c.Set(IsAdminKey, true)
+		} else {
+			c.Set(IsAdminKey, false)
+		}
+
 		c.Set(UserKey, user)
 		c.Next()
 	}

--- a/src/controllers/message.go
+++ b/src/controllers/message.go
@@ -53,7 +53,7 @@ func GetUserMessages(c *gin.Context) {
 func GetFeedMessages(c *gin.Context) {
 	messageRepository := c.MustGet(MessageRepositoryKey).(database.IMessageRepository)
 
-	user := c.MustGet("user").(*models.User)
+	user := c.MustGet(UserKey).(*models.User)
 
 	messages, err := messageRepository.GetByUserAndItsFollowers(user.UserId, perPage)
 	if err != nil {

--- a/src/controllers/message.go
+++ b/src/controllers/message.go
@@ -76,7 +76,7 @@ func PostUserMessage(c *gin.Context) {
 	urlUsername := c.Param("username")
 
 	user := c.MustGet(UserKey).(*models.User)
-	if user.Username == "simulator" {
+	if c.MustGet(IsAdminKey).(bool) {
 		userRepository := c.MustGet(UserRepositoryKey).(database.IUserRepository)
 		var err error
 		user, err = userRepository.GetByUsername(urlUsername)

--- a/src/controllers/message.go
+++ b/src/controllers/message.go
@@ -51,24 +51,9 @@ func GetUserMessages(c *gin.Context) {
 }
 
 func GetFeedMessages(c *gin.Context) {
-	userRepository := c.MustGet(UserRepositoryKey).(database.IUserRepository)
 	messageRepository := c.MustGet(MessageRepositoryKey).(database.IMessageRepository)
 
-	authUsername, err := GetAuthState(c)
-	if authUsername == "" || err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
-		return
-	}
-
-	user, err := userRepository.GetByUsername(authUsername)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if user == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-		return
-	}
+	user := c.MustGet("user").(*models.User)
 
 	messages, err := messageRepository.GetByUserAndItsFollowers(user.UserId, perPage)
 	if err != nil {

--- a/src/controllers/message.go
+++ b/src/controllers/message.go
@@ -73,20 +73,29 @@ func PostUserMessage(c *gin.Context) {
 		return
 	}
 
-	userRepository := c.MustGet(UserRepositoryKey).(database.IUserRepository)
+	urlUsername := c.Param("username")
+
+	user := c.MustGet(UserKey).(*models.User)
+	if user.Username == "simulator" {
+		userRepository := c.MustGet(UserRepositoryKey).(database.IUserRepository)
+		var err error
+		user, err = userRepository.GetByUsername(urlUsername)
+
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		if user == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+			return
+		}
+	} else if user.Username != urlUsername {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "the URL username did not match the Authorization header username"})
+		return
+	}
+
 	messageRepository := c.MustGet(MessageRepositoryKey).(database.IMessageRepository)
-
-	user, err := userRepository.GetByUsername(c.Param("username"))
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	if user == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-		return
-	}
-
 	messageRepository.Create(models.Message{
 		Author:  *user,
 		Text:    body.Content,

--- a/src/test/controllers/follow_test.go
+++ b/src/test/controllers/follow_test.go
@@ -71,7 +71,7 @@ func (suite *TestSuite) TestFollowPostController_WithoutLoggedInUser_Returns403(
 	req := httptest.NewRequest(http.MethodPost, followUrl, bytes.NewReader(body))
 	w := suite.sendRequest(req)
 
-	assert.Equal(suite.T(), http.StatusForbidden, w.Code)
+	assert.Equal(suite.T(), http.StatusUnauthorized, w.Code)
 }
 
 func (suite *TestSuite) TestFollowGetController_GivenUserWithNoFollows_ReturnsEmpty() {

--- a/src/test/controllers/message_test.go
+++ b/src/test/controllers/message_test.go
@@ -47,6 +47,7 @@ func (suite *TestSuite) Test_PostUserMessage_Returns_NoContent() {
 
 	// Act
 	req := httptest.NewRequest(http.MethodPost, "/msgs/Darrow", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Basic "+encodeCredentialsToB64("Darrow", "Reaper"))
 	w := suite.sendRequest(req)
 
 	// Assert
@@ -59,6 +60,7 @@ func (suite *TestSuite) Test_PostUserMessage_Given_NonExistent_User_Returns_NotF
 
 	// Act
 	req := httptest.NewRequest(http.MethodPost, "/msgs/Darrow", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Basic "+encodeCredentialsToB64("Darrow", "Reaper"))
 	w := suite.sendRequest(req)
 
 	// Assert
@@ -72,6 +74,22 @@ func (suite *TestSuite) Test_PostUserMessage_Given_Empty_Message_Returns_BadRequ
 
 	// Act
 	req := httptest.NewRequest(http.MethodPost, "/msgs/Darrow", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Basic "+encodeCredentialsToB64("Darrow", "Reaper"))
+	w := suite.sendRequest(req)
+
+	// Assert
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *TestSuite) Test_PostUserMessage_Given_Simulator_Returns_No_Content() {
+	// Arrange
+	suite.registerUser("Darrow", "darrow@andromedus.com", "Reaper")
+	suite.registerUser("simulator", "simulator@andromedus.com", "super_safe")
+	body, _ := json.Marshal(gin.H{"content": ""})
+
+	// Act
+	req := httptest.NewRequest(http.MethodPost, "/msgs/Darrow", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Basic "+encodeCredentialsToB64("simulator", "super_safe"))
 	w := suite.sendRequest(req)
 
 	// Assert

--- a/src/test/controllers/message_test.go
+++ b/src/test/controllers/message_test.go
@@ -84,12 +84,12 @@ func (suite *TestSuite) Test_PostUserMessage_Given_Empty_Message_Returns_BadRequ
 func (suite *TestSuite) Test_PostUserMessage_Given_Simulator_Returns_No_Content() {
 	// Arrange
 	suite.registerUser("Darrow", "darrow@andromedus.com", "Reaper")
-	suite.registerUser("simulator", "simulator@andromedus.com", "super_safe")
+	suite.registerUser("simulator", "simulator@andromedus.com", "super_safe!")
 	body, _ := json.Marshal(gin.H{"content": ""})
 
 	// Act
 	req := httptest.NewRequest(http.MethodPost, "/msgs/Darrow", bytes.NewReader(body))
-	req.Header.Set("Authorization", "Basic "+encodeCredentialsToB64("simulator", "super_safe"))
+	req.Header.Set("Authorization", "Basic "+encodeCredentialsToB64("simulator", "super_safe!"))
 	w := suite.sendRequest(req)
 
 	// Assert


### PR DESCRIPTION
Add login middleware that 
- Authenticates the credentials
- Returns the proper response if failed
- Retrieves the user to ensure they exist
- Sets the user variable on the context for easy retrieval
- Sets the `isAdmin` variable if the user is simulator

The middleware has been used in `/feed`, `/fllws/:username`, `/msgs/username` and nearly completely replaces /login