### PR TITLE
Add indexes to the database

### DIFF
--- a/src/database/message-repository.go
+++ b/src/database/message-repository.go
@@ -11,7 +11,7 @@ type MessageDTO struct {
 	AuthorId int     `gorm:"not null"`
 	Author   UserDTO `gorm:"foreignkey:AuthorId"`
 	Text     string  `gorm:"not null"`
-	PubDate  int64   `gorm:"not null"`
+	PubDate  int64   `gorm:"not null;index:,sort:desc"`
 	Flagged  bool    `gorm:"not null"`
 }
 

--- a/src/database/user-repository.go
+++ b/src/database/user-repository.go
@@ -10,7 +10,7 @@ const userTable = "user"
 type UserDTO struct {
 	gorm.Model
 
-	Username     string `gorm:"not null"`
+	Username     string `gorm:"not null;index"`
 	Email        string `gorm:"not null"`
 	PasswordHash string `gorm:"not null"`
 


### PR DESCRIPTION
To fix the slow loading times we experienced, add
- Descending index on pub_date to messages, as we always order by that
- Index on username in users as all lookups from the users end is on the username.

Fixes #60 